### PR TITLE
DEMO: LDK-sample can't be spawned in a task

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -771,5 +771,9 @@ async fn start_ldk() {
 
 #[tokio::main]
 pub async fn main() {
-	start_ldk().await;
+    tokio::spawn(async move {
+        start_ldk().await;
+    })
+        .await
+        .expect("LDK panicked")
 }


### PR DESCRIPTION
## The Problem

`cargo run <user>:<pass>@<host>:<port> .`

<details>

```bash
   Compiling ldk-tutorial-node v0.1.0 (/Users/fang/lexe/forks/ldk-sample)
error: future cannot be sent between threads safely
   --> src/main.rs:774:5
    |
774 |     tokio::spawn(async move {
    |     ^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: the trait `Sync` is not implemented for `dyn Listen`
note: future is not `Send` as this value is used across an await
   --> src/main.rs:534:5
    |
512 |           let mut chain_listeners =
    |               ------------------- has type `Vec<(BlockHash, &dyn Listen)>` which is not `Send`
...
534 |               )
    |  ______________^
535 | |             .await
    | |__________________^ await occurs here, with `mut chain_listeners` maybe used later
...
538 |       }
    |       - `mut chain_listeners` is later dropped here
note: required by a bound in `tokio::spawn`
   --> /Users/fang/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.14.1/src/task/spawn.rs:127:21
    |
127 |         T: Future + Send + 'static,
    |                     ^^^^ required by this bound in `tokio::spawn`

error: future cannot be sent between threads safely
   --> src/main.rs:774:5
    |
774 |     tokio::spawn(async move {
    |     ^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: within `impl futures::Future<Output = ()>`, the trait `std::marker::Send` is not implemented for `std::sync::MutexGuard<'_, std::io::BufReader<std::io::stdio::StdinRaw>>`
note: future is not `Send` as this value is used across an await
   --> src/cli.rs:189:75
    |
154 |       let mut line_reader = stdin.lock().lines();
    |           --------------- has type `std::io::Lines<StdinLock<'_>>` which is not `Send`
...
189 |                       if connect_peer_if_necessary(pubkey, peer_addr, peer_manager.clone())
    |  __________________________________________________________________________________________^
190 | |                         .await
    | |______________________________^ await occurs here, with `mut line_reader` maybe used later
...
467 |   }
    |   - `mut line_reader` is later dropped here
note: required by a bound in `tokio::spawn`
   --> /Users/fang/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.14.1/src/task/spawn.rs:127:21
    |
127 |         T: Future + Send + 'static,
    |                     ^^^^ required by this bound in `tokio::spawn`

error: could not compile `ldk-tutorial-node` due to 2 previous errors
[Finished running. Exit status: 101]
```

</details>

`dyn Listen` not being `Send` makes it not possible to move `ldk-sample` (and likely lots of nodes based on `ldk-sample`) into a task which could be moved across threads. We encountered this problem when we wanted to run integration tests which spawned tasks for different infrastructural components, including our LDK node.

## Comments

[`lightning-block-sync::synchronize_listeners`](https://docs.rs/lightning-block-sync/latest/lightning_block_sync/init/fn.synchronize_listeners.html) API requires `&impl Listen`. To meet this API, `ldk-sample` casts the channel manager / channel monitor into a `&dyn Listen`. However, this causes `&dyn Listen` to not be `Send`.

A solution that worked for us was to use a concrete enum rather than dynamic dispatch (roughly, omitting the generics):
```rust
enum Listener {
    ChannelMonitor(ChannelMonitorChainListenerType),
    ChannelManager(Arc<ChannelManagerType>),
}
```

then impl `Listen` on it so that the `Listener` could be passed into `lightning_block_sync` directly:

```rust
/// This [`Listen`] impl simply delegates to the inner type.
impl Listen for Listener {
    fn filtered_block_connected(
        &self,
        header: &BlockHeader,
        txdata: &TransactionData<'_>,
        height: u32,
    ) {
        match self {
            Self::ChannelMonitor(cmcl) => cmcl
                .listener
                .filtered_block_connected(header, txdata, height),
            Self::ChannelManager(cm) => {
                cm.deref().filtered_block_connected(header, txdata, height)
            }
        }
    }

    fn block_disconnected(&self, header: &BlockHeader, height: u32) {
        match self {
            Self::ChannelMonitor(cmcl) => {
                cmcl.listener.block_disconnected(header, height)
            }
            Self::ChannelManager(cm) => {
                cm.deref().block_disconnected(header, height)
            }
        }
    }
}
```